### PR TITLE
Update "pkg" command from nodejs-8 to nodejs-12.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "node ./dns-proxy.js",
     "test": "npm run test:standard",
     "test:standard": "standard *.js",
-    "pkg": "pkg --out-dir release --targets node8-macos-x64,node8-alpine-x64,node8-linux-x64,node8-win dns-proxy.js"
+    "pkg": "pkg --out-dir release --targets node12-macos-x64,node12-alpine-x64,node12-linux-x64,node12-win dns-proxy.js"
   },
   "dependencies": {
     "debug": "^4.0.0",


### PR DESCRIPTION
updating it will allow it to build functional binaries that do not return ```TypeError: Cannot destructure property `isRegExp` of 'undefined' or 'null'.```